### PR TITLE
Fixes up rendering over HTTPS link

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
         <div class="wrap">
             <a href="http://www.gsa.gov/" target="_blank">
-                <img class="logo" src="http://gsa.github.io/img/GSAlogo.gif"
+                <img class="logo" src="https://gsa.github.io/img/GSAlogo.gif"
                      alt="General Services Administration">
             </a>
             <h1><a class="home" href="/"><span>GSA</span> Open Tech</a></h1>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,8 +12,8 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <link rel="stylesheet" href="//fast.fonts.net/cssapi/0a274127-32a9-474a-bbdb-f23f410e88c5.css">
-    <link rel="stylesheet" href="http://gsa.github.io/css/site.css">
+    <link rel="stylesheet" href="https://fast.fonts.net/cssapi/0a274127-32a9-474a-bbdb-f23f410e88c5.css">
+    <link rel="stylesheet" href="https://gsa.github.io/css/site.css">
 
     <link rel="alternate" type="application/rss+xml" title="{{ site.name }} &raquo; Feed" href="/feed/">
 
@@ -45,7 +45,7 @@
 {% include footer.html %}
     </footer>
 
-    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
     <script src="{% if page.assetpath %}{{ page.assetpath }}{% endif %}js/afontgarde.js"></script>
     <script>
         AFontGarde( 'CFPB_Icons', '\uE600\uE601\uE602\uE605' );


### PR DESCRIPTION
https://gsa.github.io breaks, the stylesheet is blocked as active mixed content. This PR fixes it.
