### PR TITLE
link to other GSA data resources

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -7,10 +7,10 @@ title: Data
                 <div class="wrap">
                     <section class="intro">
                         <h1>Datasets</h1>
-                        <p>GSA has categorized its public data listing to facilitate search and an improved customer experience on this site. Click on a category below to view the datasets in that category.  APIs and their documentation are detailed in the <a href="http://open.gsa.gov/developer/">developers hub</a>.   
+                        <p>GSA has categorized its public data listing to facilitate search and an improved customer experience on this site. Click on a category below to view the datasets in that category.  APIs and their documentation are detailed in the <a href="http://open.gsa.gov/developer/">developers hub</a>.
                         </p>
                         <p>
-                        Many of our APIs are themselves open sourced and we always <a href="https://github.com/GSA/GSA-APIs/issues">welcome feedback</a>.  For more information or data requests, please contact <a href="mailto:opendata@gsa.gov">opendata@gsa.gov</a>.  
+                        Many of our APIs are themselves open sourced and we always <a href="https://github.com/GSA/GSA-APIs/issues">welcome feedback</a>.  For more information or data requests, please contact <a href="mailto:opendata@gsa.gov">opendata@gsa.gov</a>.
                         </p>
                         <ul class="learn-more">
                             <li class="learn-more_item">
@@ -31,7 +31,7 @@ title: Data
                         <h2 class="sidebar_head">Other Data Resources</h2>
                         <ul class="sidebar_list nav-list">
                             <li class="sidebar_list_item">
-                                <h3 class="sidebar_list_item_head">* <a href="https://catalog.data.gov">Data.gov</a>
+                                <h3 class="sidebar_list_item_head">* <a href="https://www.data.gov">Data.gov</a> (<a href="https://catalog.data.gov/organization/gsa-gov">GSA's Data Sets</a>)
                                 </h3>
                             </li>
                         </ul>
@@ -44,6 +44,18 @@ title: Data
                         <ul class="sidebar_list nav-list">
                             <li class="sidebar_list_item">
                                 <h3 class="sidebar_list_item_head">* <a href="http://www.gsa.gov/data.json">GSA's Public Data Listing</a>
+                                </h3>
+                            </li>
+                        </ul>
+                        <ul class="sidebar_list nav-list">
+                            <li class="sidebar_list_item">
+                                <h3 class="sidebar_list_item_head">* <a href="https://github.com/GSA/data">GSA's Open Data Repository</a>
+                                </h3>
+                            </li>
+                        </ul>
+                        <ul class="sidebar_list nav-list">
+                            <li class="sidebar_list_item">
+                                <h3 class="sidebar_list_item_head">* <a href="http://www.gsa.gov/portal/category/105839">Open Data at GSA (Deprecated)</a>
                                 </h3>
                             </li>
                         </ul>


### PR DESCRIPTION
While I believe the desire is to deprecate/consolidate them (https://github.com/GSA/open.gsa.gov/issues/17), I think it's useful to link out to the existing resources in the meantime.

![screen shot 2016-08-17 at 2 43 27 pm](https://cloud.githubusercontent.com/assets/86842/17748785/fc4606b4-6488-11e6-958f-ef4607f28ea5.png)
